### PR TITLE
fix: center footer content on mobile screens

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -11,7 +11,7 @@ export default function Footer() {
     <footer className="mt-8 border-t-4 border-[#2c2c2c] bg-[#97D4D5]">
       <div className="mx-auto max-w-6xl px-4 py-8">
         {/* Main footer content */}
-        <div className="grid gap-8 md:grid-cols-2 justify-between items-center">
+        <div className="grid gap-8 md:grid-cols-2 justify-center items-center">
           {/* Brand section */}
           <div className="text-center md:text-left">
             <Link


### PR DESCRIPTION
Fixes #1

## Problem
Footer content was not centered on mobile screens (< md breakpoint).

## Solution
Removed `justify-between` and added `justify-center` to the grid container. This centers the content on mobile while maintaining the proper two-column layout on larger screens.

## Changes
 Updated footer grid className: removed `justify-between`, added `justify-center`

## Screenshots

### Before
<img width="354" height="771" alt="Screenshot 2025-12-01 172311" src="https://github.com/user-attachments/assets/85916495-e5cd-4093-86df-47702af70914" />


### After
<img width="352" height="751" alt="image" src="https://github.com/user-attachments/assets/10e56c89-1924-4dcd-9c71-117713d1d633" />


